### PR TITLE
Fix #7

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import initTask from './task/index'
-import createTask from './task/index'
+import { createTask } from './task/index'
 import createDisposables from './disposables/index'
 import { timeout } from './disposables/index'
 


### PR DESCRIPTION
The default export is currently `ìnitTask when it should be `createTask` because of missing curly braces on an import statement.

See #7 for details.