### PR TITLE
Readme documentation link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If that isn't enough, Ency's API strikes a nice balance between declarative and 
 
 ## Documentation
 
-The [Ency documentation](ency.now.sh/ency) is a [nuxt.js](https://github.com/nuxt/nuxt.js) and [nuxtent](https://github.com/nuxt-community/nuxtent) generated static site with interactive examples.
+The [Ency documentation](https://ency.now.sh/ency) is a [nuxt.js](https://github.com/nuxt/nuxt.js) and [nuxtent](https://github.com/nuxt-community/nuxtent) generated static site with interactive examples.
 
 ## License
 


### PR DESCRIPTION
The link was missing the protocol so it was being treated as a relative link.